### PR TITLE
key-formatting-issue: Multiline keys were failing to be decoded from base64

### DIFF
--- a/src/main/java/uk/gov/di/ipv/atp/dcs/utils/KeyReader.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/utils/KeyReader.java
@@ -16,10 +16,10 @@ public abstract class KeyReader {
     public static Key loadKey(String key) throws NoSuchAlgorithmException, InvalidKeySpecException {
         var factory = KeyFactory.getInstance("RSA");
         var stripped = key
-            .replaceAll("-----BEGIN RSA PRIVATE KEY----- ", "")
-            .replaceAll("-----BEGIN PRIVATE KEY----- ", "") //TODO: Remove this line after updating scripts to generate rsa format key
-            .replaceAll(" -----END RSA PRIVATE KEY-----", "")
-            .replaceAll(" -----END PRIVATE KEY-----", "") //TODO: Remove this line after updating scripts to generate rsa format key
+            .replaceAll("-----BEGIN RSA PRIVATE KEY-----", "")
+            .replaceAll("-----BEGIN PRIVATE KEY-----", "") //TODO: Remove this line after updating scripts to generate rsa format key
+            .replaceAll("-----END RSA PRIVATE KEY-----", "")
+            .replaceAll("-----END PRIVATE KEY-----", "") //TODO: Remove this line after updating scripts to generate rsa format key
             .replaceAll("\"", "")
             .replaceAll("\\s+", "");
         var decoded = Base64.getDecoder().decode(stripped);


### PR DESCRIPTION
## Whats changed

- Intellij kindly formats all env vars to a single line, missing this issue when debugging locally,
  updating the replaceAll to remove the spaces which the app failed to match.