### PR TITLE
cert-format: Fixing the cert formatting issue when certificates are multiline

### DIFF
--- a/src/main/java/uk/gov/di/ipv/atp/dcs/utils/KeyReader.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/utils/KeyReader.java
@@ -30,8 +30,8 @@ public abstract class KeyReader {
     public static Certificate loadCertFromString(String cert) throws CertificateException {
         var factory = CertificateFactory.getInstance("X.509");
         var stripped = cert
-            .replaceAll("-----BEGIN CERTIFICATE----- ", "")
-            .replaceAll(" -----END CERTIFICATE-----", "")
+            .replaceAll("-----BEGIN CERTIFICATE-----", "")
+            .replaceAll("-----END CERTIFICATE-----", "")
             .replaceAll("\"", "")
             .replaceAll("\\s+", "");
         var decoded = Base64.getDecoder().decode(stripped);


### PR DESCRIPTION
## Whats changed

- Removing the space from replaceAll for certs.