### PR TITLE
timestamps: Adding a correct serde instant converter for gson.

### DIFF
--- a/src/main/java/uk/gov/di/ipv/atp/dcs/config/AtpConfig.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/config/AtpConfig.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.atp.dcs.config;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -10,11 +11,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 import uk.gov.di.ipv.atp.dcs.domain.Thumbprints;
+import uk.gov.di.ipv.atp.dcs.utils.InstantConverter;
 import uk.gov.di.ipv.atp.dcs.utils.KeyReader;
 
 import javax.net.ssl.SSLException;
@@ -23,6 +24,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
+import java.time.Instant;
 import java.util.Base64;
 
 @Slf4j
@@ -68,7 +70,9 @@ public class AtpConfig {
     @Bean
     @Primary
     Gson gson() {
-        return new Gson();
+        return new GsonBuilder()
+            .registerTypeAdapter(Instant.class, new InstantConverter())
+            .create();
     }
 
     @Bean("atp-ipv-signing-key")

--- a/src/main/java/uk/gov/di/ipv/atp/dcs/utils/InstantConverter.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/utils/InstantConverter.java
@@ -1,7 +1,12 @@
 package uk.gov.di.ipv.atp.dcs.utils;
 
-
-import com.google.gson.*;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
 import java.time.Instant;

--- a/src/main/java/uk/gov/di/ipv/atp/dcs/utils/InstantConverter.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/utils/InstantConverter.java
@@ -1,0 +1,23 @@
+package uk.gov.di.ipv.atp.dcs.utils;
+
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+public class InstantConverter implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_INSTANT;
+
+    @Override
+    public JsonElement serialize(Instant src, Type typeOfSrc, JsonSerializationContext context) {
+        return new JsonPrimitive(FORMATTER.format(src));
+    }
+
+    @Override
+    public Instant deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        return FORMATTER.parse(json.getAsString(), Instant::from);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
   main:
     banner-mode: off
 
-mockDcs: false
+mockDcs: ${IPV_ATP_DCS_SHOULD_MOCK:false}
 
 atp:
   ipv:


### PR DESCRIPTION
## Whats changed

- Gson converts instants to seconds and nanoseconds, this formats it to an ISO string.
- Externalising the `mockDcs` flag so that this can be triggered via config change rather than a code deploy.