### PR TITLE
timestamps-2: Adding a data adapter to shape the timestamp to the yyyy-MM-dd format

### DIFF
--- a/src/main/java/uk/gov/di/ipv/atp/dcs/domain/DcsPayload.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/domain/DcsPayload.java
@@ -1,7 +1,9 @@
 package uk.gov.di.ipv.atp.dcs.domain;
 
+import com.google.gson.annotations.JsonAdapter;
 import lombok.Builder;
 import lombok.Getter;
+import uk.gov.di.ipv.atp.dcs.utils.InstantShortDateAdapter;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -16,6 +18,10 @@ public class DcsPayload {
     private final String passportNumber;
     private final String surname;
     private final String[] forenames;
+
+    @JsonAdapter(InstantShortDateAdapter.class)
     private final Instant dateOfBirth;
+
+    @JsonAdapter(InstantShortDateAdapter.class)
     private final Instant expiryDate;
 }

--- a/src/main/java/uk/gov/di/ipv/atp/dcs/utils/InstantConverter.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/utils/InstantConverter.java
@@ -10,11 +10,16 @@ import com.google.gson.JsonSerializer;
 
 import java.lang.reflect.Type;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 public class InstantConverter implements JsonSerializer<Instant>, JsonDeserializer<Instant> {
 
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_INSTANT;
+    private static final String LONG_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter
+        .ofPattern(LONG_PATTERN)
+        .withZone(ZoneId.from(ZoneOffset.UTC));
 
     @Override
     public JsonElement serialize(Instant src, Type typeOfSrc, JsonSerializationContext context) {

--- a/src/main/java/uk/gov/di/ipv/atp/dcs/utils/InstantShortDateAdapter.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/utils/InstantShortDateAdapter.java
@@ -1,0 +1,39 @@
+package uk.gov.di.ipv.atp.dcs.utils;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+public class InstantShortDateAdapter extends TypeAdapter<Instant> {
+
+    private static final String SHORT_FORMAT = "yyyy-MM-dd";
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter
+        .ofPattern(SHORT_FORMAT)
+        .withZone(ZoneId.from(ZoneOffset.UTC));
+
+    @Override
+    public void write(JsonWriter out, Instant value) throws IOException {
+        if (value != null) {
+            out.value(FORMATTER.format(value));
+        }
+
+        out.flush();
+    }
+
+    @Override
+    public Instant read(JsonReader in) throws IOException {
+        if (in.peek().equals(JsonToken.NULL)) {
+            throw new RuntimeException("Failed to deserialize date, null token provided");
+        }
+
+        var next = in.nextString();
+        return FORMATTER.parse(next, Instant::from);
+    }
+}


### PR DESCRIPTION
## Whats changed

- Updating the timestamps for the dob and expiry dates to exclude the time and offset.
- The timestamp timestamp uses milliseconds instead of nanoseconds.