### PR TITLE
PYI-23: mTLS - reverting insecure trust manager

### DIFF
--- a/src/main/java/uk/gov/di/ipv/atp/dcs/config/AtpConfig.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/config/AtpConfig.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,7 +18,10 @@ import uk.gov.di.ipv.atp.dcs.utils.InstantConverter;
 import uk.gov.di.ipv.atp.dcs.utils.KeyReader;
 
 import javax.net.ssl.SSLException;
-import java.security.*;
+import java.security.Key;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -62,8 +64,7 @@ public class AtpConfig {
         return SslContextBuilder
             .forClient()
             .keyManager((PrivateKey) clientKey, (X509Certificate) clientCert)
-//            .trustManager((X509Certificate) serverCert)
-            .trustManager(InsecureTrustManagerFactory.INSTANCE) // TODO: Remove this
+            .trustManager((X509Certificate) serverCert)
             .build();
     }
 

--- a/src/main/java/uk/gov/di/ipv/atp/dcs/services/impl/DcsServiceImpl.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/services/impl/DcsServiceImpl.java
@@ -71,10 +71,25 @@ public class DcsServiceImpl implements DcsService {
             .header("content-type", "application/jose")
             .exchangeToMono(clientResponse -> {
                 if (clientResponse.statusCode().equals(HttpStatus.OK)) {
+                    log.info(
+                        "Received a 200 response from DCS (requestId: {}, correlationId: {})",
+                        dcsPayload.getRequestId(),
+                        dcsPayload.getCorrelationId()
+                    );
                     return clientResponse.bodyToMono(String.class);
                 } else if (clientResponse.statusCode().is4xxClientError()) {
+                    log.warn(
+                        "Received a 4xx response from DCS (requestId: {}, correlationId: {})",
+                        dcsPayload.getRequestId(),
+                        dcsPayload.getCorrelationId()
+                    );
                     return Mono.just("DCS responded with a 4xx error");
                 } else {
+                    log.error(
+                        "Unable to process request (requestId: {}, correlationId: {})",
+                        dcsPayload.getRequestId(),
+                        dcsPayload.getCorrelationId()
+                    );
                     return clientResponse.createException()
                         .flatMap(Mono::error);
                 }

--- a/src/main/java/uk/gov/di/ipv/atp/dcs/services/impl/DcsServiceImpl.java
+++ b/src/main/java/uk/gov/di/ipv/atp/dcs/services/impl/DcsServiceImpl.java
@@ -46,7 +46,7 @@ public class DcsServiceImpl implements DcsService {
         var correlationId = UUID.randomUUID();
         var requestId = UUID.randomUUID();
 
-        log.info(String.format("Creating new DCS payload (correlationId: %s, requestId: %s)", correlationId, requestId));
+        log.info("Creating new DCS payload (requestId: {}, correlationId: {})", requestId, correlationId);
 
         return DcsPayload.builder()
             .correlationId(correlationId)


### PR DESCRIPTION
## Whats changed

- The updated mTLS DCS server certificate in the pipeline is now the correct one. Therefore we can revert back to using it as the trust manager.
- Added some additional logging.
